### PR TITLE
2 Week 미션 수행

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom ###
+src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,12 @@ dependencies {
 
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect' // 타임리프에서 layout.html 사용하려고
+
+    // Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/records/2Week_허준홍.md
+++ b/records/2Week_허준홍.md
@@ -1,0 +1,77 @@
+## [2Week] 허준홍
+
+### 미션 요구사항 분석 & 체크리스트
+
+---
+
+- [x] 케이스 4 : 한명의 인스타회원이 다른 인스타회원에게 중복으로 호감표시를 할 수 없습니다.
+  - [x] 같은 대상에게 호감을 표시하면 중복으로 이기 때문에 처리를 하지 않는다. (rq.historyBack)
+
+
+- [x] 케이스 5 : 한명의 인스타회원이 11명 이상의 호감상대를 등록 할 수 없습니다.
+  - [x] 10명까지 호감표시를 하고 11명 째 호감표시에서 처리되면 안된다. (rq.historyBack)
+
+  
+- [x] 케이스 6 : 케이스 4 가 발생했을 때 기존의 사유와 다른 사유로 호감을 표시하는 경우에는 성공으로 처리
+  - [x] 같은 대상에게 호감을 표시할 때 사유가 다르다면 수정으로 처리하고 사유만 수정한다.
+  - [x] resultCode = S-2
+  - [x] msg=bbbb 에 대한 호감사유를 외모에서 성격으로 변경합니다.
+
+
+- [x] 네이버 로그인
+    - [x] 스프링 OAuth2 클라이언트로 구현
+    - [x] 네이버 로그인으로 가입한 회원의 providerTypeCode : NAVER
+
+
+
+
+### 2주차 미션 요약
+
+---
+**[접근 방법]**
+
+체크리스트를 중심으로 각각의 기능을 구현하기 위해 어떤 생각을 했는지 정리합니다. .
+
+- 같은 대상에게 호감을 표시하면 중복으로 이기 때문에 처리를 하지 않는다. (rq.historyBack)
+  - 먼저 같은대상을 찾는게 중요하다고 생각했다. LikeablePerson에서 fromInstamember가 현재 로그인한 member의 instamember와 동일한 접속자이다.
+  - 이 상태에서 addForm에서 전달받은 username이 호감을 표시하고 등록하려는 대상이다. 그렇다면 LikeablePerson에서 toInstamember의 username 전달받은 username과
+똑같으면 이미 호감을 표시하여 LikeablePerson에 저장되어 있는 대상이기 때문에 중복으로 처리한다. exist라는 메서드를 만들어 existLikeablePeople에 저장했다.
+  - 처음에는 로그인한 member의 instamember의 getFromLikealbePeople()을 이용해서 List를 다 불러 온 후 반복문으로 찾아냈지만, 이 후에
+    JPA 함수에서 언더바(_)를 사용하여 관련 엔티티의 필드까지 검색조건으로 활용하여 필요한 LikeablePerson을 한 번에 불러오도록 했다.
+  - historyBack은 rsData.of를 F-x (Fail)로 return하여 historyBack이 되도록 했다.
+
+
+- 10명까지 호감표시를 하고 11명 째 호감표시에서 처리되면 안된다. (rq.historyBack)
+  - 로그인한 member의 instamember의 getFromLikealbePeople()을 이용해서 List를 다 불러와 list의 size()를 10명 이상이 되면 rsData.of로 Fail을 return하도록 했다.
+  - rsData.of를 F-x (Fail)로 return하여 historyBack이 되도록 했다.
+
+
+- 같은 대상에게 호감을 표시할 때 사유가 다르다면 수정으로 처리하고 사유만 수정한다.
+  - 이미 존재하는 대상의 LikealbePerson의 정보가 담긴 객체 existLikeablePeople의 호감 사유인 getAttractiveTypeCode()가 
+새로 입력받아 들어온 attractiveTypeCode와 다르면 수정으로 처리하도록 했다.
+  - modify(existLikeablePeople,attractiveTypeCode) 메서드를 이용해서 기존의 호감사유를 String beforeAttractive 에 저장해두고
+호감 사유를 attractiveTypeCode로 수정하였다.
+  - 수정 성공의 msg에는 "%s에 대한 호감사유를 %s에서 %s으로 변경합니다.".formatted(modifyLikeablePeople.getToInstaMember().getUsername()
+    ,beforeAttractive,modifyLikeablePeople.getAttractiveTypeDisplayName()),modifyLikeablePeople 을 이용했다.
+  - 현재 수정하는 [호감대상의 이름]에 대한 [이전의 호감사유]에서 [새로 받아온 attractiveTypeCode(호감사유)]으로 변경합니다.
+
+
+- 스프링 OAuth2 클라이언트로 구현
+  - 네이버 API에서 API 생성후 OAuth 클라이언트 ID 와 비밀번호를 발급 받았다.
+  - 발급 받은 클라이언트 ID와 비밀번호를 yml에 추가했고 provider도 등록해주었다.
+
+
+
+- 네이버 로그인으로 가입한 회원의 providerTypeCode : NAVER
+  - 카카오톡 로그인을 위해 구현되어 있던 CustomOAuth2UserService.java를 통해 NAVER 로그인을 가능케 했다.
+  - whenSocialLogin을 통해 최초 로그인 시 join이 발생
+  - 소셜 로그인으로 로그인할 때는 비밀번호가 없다.
+
+
+**[특이사항]**
+
+구현 과정에서 아쉬웠던 점 / 궁금했던 점을 정리합니다.
+
+- 네이버 로그인시 provider에서 user-name-attribute: response 로 받아오다 보니 id뿐만 아니라 다른 정보들도 한 번에 oauthId에 저장이 되어서
+정보를 따로 불러오기 위해 OAuth2UserInfo를 상속받은 NaverUserInfo를 만들었는데 아직 어떻게 동작하는지 완벽하게 이해가 되지 않는다.
+

--- a/src/main/java/com/ll/gramgram/base/BaseEntity.java
+++ b/src/main/java/com/ll/gramgram/base/BaseEntity.java
@@ -1,0 +1,34 @@
+package com.ll.gramgram.base;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@MappedSuperclass // 각각의 Entity클래스의 공통 정보를 담은 상위 클래스를 만들기 위해서 붙여야함
+@EntityListeners(AuditingEntityListener.class) // @CreatedDate, @LastModifiedDate 작동하게 허용
+@Getter
+@ToString
+@NoArgsConstructor
+@SuperBuilder //
+public class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    @CreatedDate
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+}

--- a/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
+++ b/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
@@ -1,0 +1,17 @@
+package com.ll.gramgram.base.appConfig;
+
+import jakarta.validation.Valid;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+    @Getter
+    private static long likeablePersonFromMax;
+
+    @Value("${custom.likeablePerson.from.max}")
+    public void setLikeablePersonFromMax (long likeablePersonFromMax){
+        AppConfig.likeablePersonFromMax = likeablePersonFromMax;
+    }
+}

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -29,6 +29,8 @@ public class NotProd {
 
             Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733201246").getData();
             Member memberUser6ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__115796413862811140673").getData();
+            Member memberUser7ByNaver = memberService.whenSocialLogin("NAVER", "NAVER__ceu8FT680lwPy5lBPD9uKSzkpAGonC01ivZ0mz8Z7gs").getData();
+
             // 이걸 해줘야
 
             instaMemberService.connect(memberUser2, "insta_user2", "M");

--- a/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
+++ b/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.ll.gramgram.base.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
@@ -1,5 +1,7 @@
 package com.ll.gramgram.base.security;
 
+import com.ll.gramgram.base.userInfo.NaverUserInfo;
+import com.ll.gramgram.base.userInfo.OAuth2UserInfo;
 import com.ll.gramgram.boundedContext.member.entity.Member;
 import com.ll.gramgram.boundedContext.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +35,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String providerTypeCode = userRequest.getClientRegistration().getRegistrationId().toUpperCase();
 
-        String username = providerTypeCode + "__%s".formatted(oauthId);
+        String username = null;
+
+        if(providerTypeCode.equals("NAVER")){
+            // 네이버 로그인 info 생성
+            OAuth2UserInfo oAuth2UserInfo = new NaverUserInfo(oAuth2User.getAttributes());
+            // 네이버 로그인 정보 중 id값만을 이용해서 로그인 정보 표시
+            username = providerTypeCode + "__%s".formatted(oAuth2UserInfo.getProviderId());
+        }
+        else{
+            username = providerTypeCode + "__%s".formatted(oauthId);
+        }
+
 
         Member member = memberService.whenSocialLogin(providerTypeCode, username).getData();
 

--- a/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
@@ -47,7 +47,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             username = providerTypeCode + "__%s".formatted(oauthId);
         }
 
-
         Member member = memberService.whenSocialLogin(providerTypeCode, username).getData();
 
         return new CustomOAuth2User(member.getUsername(), member.getPassword(), member.getGrantedAuthorities());

--- a/src/main/java/com/ll/gramgram/base/userInfo/NaverUserInfo.java
+++ b/src/main/java/com/ll/gramgram/base/userInfo/NaverUserInfo.java
@@ -1,0 +1,41 @@
+package com.ll.gramgram.base.userInfo;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class NaverUserInfo implements OAuth2UserInfo{
+    private Map<String, Object> attributes; //OAuth2User.getAttributes();
+    private Map<String, Object> attributesResponse;
+
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.attributes = (Map<String, Object>) attributes.get("response");
+        this.attributesResponse = (Map<String, Object>) attributes.get("response");
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributesResponse.get("id").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getEmail() {
+        return attributesResponse.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributesResponse.get("name").toString();
+    }
+}

--- a/src/main/java/com/ll/gramgram/base/userInfo/OAuth2UserInfo.java
+++ b/src/main/java/com/ll/gramgram/base/userInfo/OAuth2UserInfo.java
@@ -1,0 +1,11 @@
+package com.ll.gramgram.base.userInfo;
+
+import java.util.Map;
+
+public interface OAuth2UserInfo {
+    Map<String, Object> getAttributes();
+    String getProviderId();
+    String getProvider();
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -1,8 +1,10 @@
 package com.ll.gramgram.boundedContext.instaMember.entity;
 
+import com.ll.gramgram.base.BaseEntity;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,21 +17,12 @@ import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-@ToString
 @Entity
 @Getter
-public class InstaMember {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-    @CreatedDate
-    private LocalDateTime createDate;
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
+@NoArgsConstructor
+@ToString(callSuper = true) // 디버그를 위한
+@SuperBuilder
+public class InstaMember extends BaseEntity {
     @Column(unique = true)
     private String username;
     @Setter

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -46,13 +46,21 @@ public class LikeablePersonController {
             return rq.historyBack(canLikeRsData);
         }
 
-        RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
+        RsData rsData;
 
-        if (createRsData.isFail()) {
-            return rq.historyBack(createRsData);
+        if(canLikeRsData.getResultCode().equals("S-2")){
+            // 이미 등록된 호감대상의 호감 사유만 바꾸는 경우
+            rsData = likeablePersonService.modifyAttractive(canLikeRsData.getData(), addForm.attractiveTypeCode);
+        }else{
+            // 호감표시에 문제가 없고 호감 대상 추가하는 경우
+            rsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
         }
 
-        return rq.redirectWithMsg("/likeablePerson/list", createRsData);
+        if (rsData.isFail()) {
+            return rq.historyBack(rsData);
+        }
+
+        return rq.redirectWithMsg("/likeablePerson/list", rsData);
     }
 
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -39,28 +39,13 @@ public class LikeablePersonController {
 
     @PostMapping("/add")
     public String add(@Valid AddForm addForm) {
+        RsData<LikeablePerson> addRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
 
-        RsData<LikeablePerson> canLikeRsData = likeablePersonService.canLike(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
-
-        if (canLikeRsData.isFail()) {
-            return rq.historyBack(canLikeRsData);
+        if (addRsData.isFail()) {
+            return rq.historyBack(addRsData);
         }
 
-        RsData rsData;
-
-        if(canLikeRsData.getResultCode().equals("S-2")){
-            // 이미 등록된 호감대상의 호감 사유만 바꾸는 경우
-            rsData = likeablePersonService.modifyAttractive(canLikeRsData.getData(), addForm.attractiveTypeCode);
-        }else{
-            // 호감표시에 문제가 없고 호감 대상 추가하는 경우
-            rsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
-        }
-
-        if (rsData.isFail()) {
-            return rq.historyBack(rsData);
-        }
-
-        return rq.redirectWithMsg("/likeablePerson/list", rsData);
+        return rq.redirectWithMsg("/likeablePerson/list", addRsData);
     }
 
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -39,6 +39,7 @@ public class LikeablePersonController {
 
     @PostMapping("/add")
     public String add(@Valid AddForm addForm) {
+
         RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
 
         if (createRsData.isFail()) {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -40,6 +40,12 @@ public class LikeablePersonController {
     @PostMapping("/add")
     public String add(@Valid AddForm addForm) {
 
+        RsData<LikeablePerson> canLikeRsData = likeablePersonService.canLike(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
+
+        if (canLikeRsData.isFail()) {
+            return rq.historyBack(canLikeRsData);
+        }
+
         RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
 
         if (createRsData.isFail()) {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -18,6 +18,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @ToString
 @Entity
 @Getter
+@Setter
 public class LikeablePerson {
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -1,8 +1,10 @@
 package com.ll.gramgram.boundedContext.likeablePerson.entity;
 
+import com.ll.gramgram.base.BaseEntity;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,23 +13,13 @@ import java.time.LocalDateTime;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-@ToString
 @Entity
 @Getter
+@NoArgsConstructor
+@ToString(callSuper = true) // 디버그를 위한
+@SuperBuilder
 @Setter
-public class LikeablePerson {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-    @CreatedDate
-    private LocalDateTime createDate;
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
-
+public class LikeablePerson extends BaseEntity {
     @ManyToOne
     @ToString.Exclude //양방향 관계에 대해서 출력에 문제가 발생할 수 있기 때문에 작성해주었다.
     private InstaMember fromInstaMember; // 호감을 표시한 사람(인스타 멤버)

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
+
+    LikeablePerson findByFromInstaMemberIdAndToInstaMember_username(Long id, String username);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -64,6 +64,7 @@ public class LikeablePersonService {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
     }
 
+    @Transactional
     public RsData<LikeablePerson> modifyAttractive(LikeablePerson modifyLikeablePeople, int attractiveTypeCode){
         // 수정 전의 호감 사유
         String beforeAttractive = modifyLikeablePeople.getAttractiveTypeDisplayName();
@@ -95,15 +96,13 @@ public class LikeablePersonService {
 
     @Transactional
     public RsData<LikeablePerson> delete(LikeablePerson likeablePeople) {
-
-
-
         String toInstaMemberUsername = likeablePeople.getToInstaMember().getUsername();
         likeablePersonRepository.delete(likeablePeople);
         return RsData.of("S-1","%s에 대한 호감이 삭제 되었습니다.".formatted(toInstaMemberUsername));
     }
 
 
+    @Transactional
     public RsData<LikeablePerson> canLike(Member actor, String username, int attractiveTypeCode) {
         int like_List_Max = (int)AppConfig.getLikeablePersonFromMax();
 
@@ -116,12 +115,13 @@ public class LikeablePersonService {
 
         if(existLikeablePeople != null){
             if(existLikeablePeople.getAttractiveTypeCode() != attractiveTypeCode){
-                return modifyAttractive(existLikeablePeople,attractiveTypeCode);
+                //return modifyAttractive(existLikeablePeople,attractiveTypeCode);
+                return RsData.of("S-2","수정 가능합니다.",existLikeablePeople);
             }
             return RsData.of("F-3", "중복으로 호감표시를 할 수 없습니다.");
         }
-        else if(existLikeablePeople == null)
-            return RsData.of("S-2", "%s에 대해 호감표시가 가능합니다.".formatted(username));
+//        else if(existLikeablePeople == null)
+//            return RsData.of("S-2", "%s에 대해 호감표시가 가능합니다.".formatted(username));
 
         if (actor.getInstaMember().getUsername().equals(username)) {
             return RsData.of("F-1", "본인을 호감상대로 등록할 수 없습니다.");

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -64,7 +64,7 @@ public class LikeablePersonService {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
     }
 
-    public RsData<LikeablePerson> modify(LikeablePerson modifyLikeablePeople, int attractiveTypeCode){
+    public RsData<LikeablePerson> modifyAttractive(LikeablePerson modifyLikeablePeople, int attractiveTypeCode){
         // 수정 전의 호감 사유
         String beforeAttractive = modifyLikeablePeople.getAttractiveTypeDisplayName();
 
@@ -116,7 +116,7 @@ public class LikeablePersonService {
 
         if(existLikeablePeople != null){
             if(existLikeablePeople.getAttractiveTypeCode() != attractiveTypeCode){
-                return modify(existLikeablePeople,attractiveTypeCode);
+                return modifyAttractive(existLikeablePeople,attractiveTypeCode);
             }
             return RsData.of("F-3", "중복으로 호감표시를 할 수 없습니다.");
         }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -42,6 +42,10 @@ public class LikeablePersonService {
         }
 
         InstaMember fromInstaMember = member.getInstaMember();
+        // 호감 표시 대상 10명 체크
+        List<LikeablePerson> fromLikeableList = fromInstaMember.getFromLikealbePeople();
+        if(fromLikeableList.size()>=10) return RsData.of("F-3", "호감표시는 10명을 넘을 수 없습니다.");
+
         InstaMember toInstaMember = instaMemberService.findByUsernameOrCreate(username).getData();
 
         LikeablePerson likeablePerson = LikeablePerson

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -28,6 +28,7 @@ public class LikeablePersonService {
             return RsData.of("F-2", "먼저 본인의 인스타그램 아이디를 입력해야 합니다.");
         }
 
+        // 등록하려는 대상이 이미 호감 목록에 존재하는지 확인
         LikeablePerson existLikeablePeople = exist(member.getInstaMember(), username);
 
         if(existLikeablePeople != null){

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -27,6 +27,12 @@ public class LikeablePersonService {
             return RsData.of("F-2", "먼저 본인의 인스타그램 아이디를 입력해야 합니다.");
         }
 
+        LikeablePerson existLikeablePeople = exist(member.getInstaMember(), username);
+
+        if(existLikeablePeople != null){
+            return RsData.of("F-3", "중복으로 호감표시를 할 수 없습니다.");
+        }
+
         if (member.getInstaMember().getUsername().equals(username)) {
             return RsData.of("F-1", "본인을 호감상대로 등록할 수 없습니다.");
         }
@@ -43,6 +49,7 @@ public class LikeablePersonService {
                 .attractiveTypeCode(attractiveTypeCode) // 1=외모, 2=능력, 3=성격
                 .build();
 
+
         likeablePersonRepository.save(likeablePerson); // 저장
         // 니가 좋아하는 호감표시 하나 생겼다.
         fromInstaMember.addFromLikeablePerson(likeablePerson);
@@ -53,8 +60,35 @@ public class LikeablePersonService {
         return RsData.of("S-1", "입력하신 인스타유저(%s)를 호감상대로 등록되었습니다.".formatted(username), likeablePerson);
     }
 
+    public LikeablePerson exist(InstaMember instaMember, String username) {
+        List<LikeablePerson> fromLikeableList = instaMember.getFromLikealbePeople();
+
+        Optional<InstaMember> toInstamember = instaMemberService.findByUsername(username);
+
+        if(toInstamember.isPresent()){
+            for(LikeablePerson li : fromLikeableList){
+                if(li.getFromInstaMember().getId().equals(instaMember.getId()) && li.getToInstaMember().getId().equals(toInstamember.get().getId())){
+
+                    return li;
+                }
+            }
+        }
+        return null;
+    }
+
     public List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId) {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
+    }
+
+    public RsData<LikeablePerson> modify(LikeablePerson modifyLikeablePeople, int attractiveTypeCode){
+        // 수정 전의 호감 사유
+        String beforeAttractive = modifyLikeablePeople.getAttractiveTypeDisplayName();
+
+        // 호감 사유 수정
+        modifyLikeablePeople.setAttractiveTypeCode(attractiveTypeCode);
+
+        return RsData.of("S-2","%s에 대한 호감사유를 %s에서 %s으로 변경합니다.".formatted(modifyLikeablePeople.getToInstaMember().getUsername()
+                ,beforeAttractive,modifyLikeablePeople.getAttractiveTypeDisplayName()),modifyLikeablePeople);
     }
 
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class LikeablePersonService {
+
     private final LikeablePersonRepository likeablePersonRepository;
     private final InstaMemberService instaMemberService;
 
@@ -27,6 +28,13 @@ public class LikeablePersonService {
         if (!member.hasConnectedInstaMember()) {
             return RsData.of("F-1", "먼저 본인의 인스타그램 아이디를 입력해주세요.");
         }
+
+        RsData<LikeablePerson> canLikeRsdata = canLike(member, username, attractiveTypeCode);
+
+        if(canLikeRsdata.isFail()) return canLikeRsdata;
+
+        if(canLikeRsdata.getResultCode().equals("S-2")) return modifyAttractive(canLikeRsdata.getData(),attractiveTypeCode);
+
 
         InstaMember fromInstaMember = member.getInstaMember();
         InstaMember toInstaMember = instaMemberService.findByUsernameOrCreate(username).getData();

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -30,6 +30,10 @@ public class LikeablePersonService {
         LikeablePerson existLikeablePeople = exist(member.getInstaMember(), username);
 
         if(existLikeablePeople != null){
+            if(existLikeablePeople.getAttractiveTypeCode() != attractiveTypeCode){
+                return modify(existLikeablePeople,attractiveTypeCode);
+            }
+
             return RsData.of("F-3", "중복으로 호감표시를 할 수 없습니다.");
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -71,17 +71,11 @@ public class LikeablePersonService {
     }
 
     public LikeablePerson exist(InstaMember instaMember, String username) {
-        List<LikeablePerson> fromLikeableList = instaMember.getFromLikealbePeople();
 
-        Optional<InstaMember> toInstamember = instaMemberService.findByUsername(username);
+        LikeablePerson existLikeablePerson = likeablePersonRepository.findByFromInstaMemberIdAndToInstaMember_username(instaMember.getId(),username);
 
-        if(toInstamember.isPresent()){
-            for(LikeablePerson li : fromLikeableList){
-                if(li.getFromInstaMember().getId().equals(instaMember.getId()) && li.getToInstaMember().getId().equals(toInstamember.get().getId())){
-
-                    return li;
-                }
-            }
+        if(existLikeablePerson !=  null){
+            return existLikeablePerson;
         }
         return null;
     }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -1,5 +1,6 @@
 package com.ll.gramgram.boundedContext.likeablePerson.service;
 
+import com.ll.gramgram.base.appConfig.AppConfig;
 import com.ll.gramgram.base.exception.DataNotFoundException;
 import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
@@ -33,7 +34,6 @@ public class LikeablePersonService {
             if(existLikeablePeople.getAttractiveTypeCode() != attractiveTypeCode){
                 return modify(existLikeablePeople,attractiveTypeCode);
             }
-
             return RsData.of("F-3", "중복으로 호감표시를 할 수 없습니다.");
         }
 
@@ -42,9 +42,12 @@ public class LikeablePersonService {
         }
 
         InstaMember fromInstaMember = member.getInstaMember();
+
+        int like_List_Max = (int)AppConfig.getLikeablePersonFromMax();
         // 호감 표시 대상 10명 체크
         List<LikeablePerson> fromLikeableList = fromInstaMember.getFromLikealbePeople();
-        if(fromLikeableList.size()>=10) return RsData.of("F-3", "호감표시는 10명을 넘을 수 없습니다.");
+        if(fromLikeableList.size() >= like_List_Max)
+            return RsData.of("F-3", "호감표시는 %d명을 넘을 수 없습니다.".formatted(like_List_Max));
 
         InstaMember toInstaMember = instaMemberService.findByUsernameOrCreate(username).getData();
 
@@ -56,7 +59,6 @@ public class LikeablePersonService {
                 .toInstaMemberUsername(toInstaMember.getUsername()) // 중요하지 않음
                 .attractiveTypeCode(attractiveTypeCode) // 1=외모, 2=능력, 3=성격
                 .build();
-
 
         likeablePersonRepository.save(likeablePerson); // 저장
         // 니가 좋아하는 호감표시 하나 생겼다.

--- a/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
@@ -1,8 +1,10 @@
 package com.ll.gramgram.boundedContext.member.entity;
 
+import com.ll.gramgram.base.BaseEntity;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -15,21 +17,14 @@ import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-@Builder // Member.builder().providerTypeCode(providerTypeCode) .. 이런식으로 쓸 수 있게 해주는
+//@Builder // Member.builder().providerTypeCode(providerTypeCode) .. 이런식으로 쓸 수 있게 해주는
+//@AllArgsConstructor // @Builder 붙이면 이거 필수
 @NoArgsConstructor // @Builder 붙이면 이거 필수
-@AllArgsConstructor // @Builder 붙이면 이거 필수
-@EntityListeners(AuditingEntityListener.class) // @CreatedDate, @LastModifiedDate 작동하게 허용
-@ToString // 디버그를 위한
+@ToString(callSuper = true) // 디버그를 위한
+@SuperBuilder
 @Entity // 아래 클래스는 member 테이블과 대응되고, 아래 클래스의 객체는 테이블의 row와 대응된다.
 @Getter // 아래 필드에 대해서 전부다 게터를 만든다. private Long id; => public Long getId() { ... }
-public class Member {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-    @CreatedDate // 아래 칼럼에는 값이 자동으로 들어간다.(INSERT 할 때)
-    private LocalDateTime createDate;
-    @LastModifiedDate // 아래 칼럼에는 값이 자동으로 들어간다.(UPDATE 할 때 마다)
-    private LocalDateTime modifyDate;
+public class Member extends BaseEntity {
     private String providerTypeCode; // 일반회원인지, 카카오로 가입한 회원인지, 구글로 가입한 회원인지
     @Column(unique = true)
     private String username;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,8 @@ logging:
     com.ll.gramgram_ai: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
+custom:
+  likeablePerson:
+    from:
+      max: 10
+

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -23,13 +23,19 @@
 
 <body>
 
+<!-- 폰트어썸 아이콘 -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+<!-- 아이콘 목록 : https://fontawesome.com/search?o=r&m=free -->
+
 <!-- 데이지 UI 불러오기 -->
 <link href="https://cdn.jsdelivr.net/npm/daisyui@2.51.5/dist/full.css" rel="stylesheet" type="text/css"/>
+
 <!-- 테일윈드 불러오기 -->
 <script src="https://cdn.tailwindcss.com"></script>
 
 <!-- 공통 상단 -->
-<header>
+<header class="sticky top-0">
+    <!--
     <a href="/" class="btn btn-link">메인</a>
     <a href="/member/login" th:if="${@rq.logout}" class="btn btn-link">로그인</a>
     <a href="/member/join" th:if="${@rq.logout}" class="btn btn-link">회원가입</a>
@@ -41,9 +47,48 @@
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
     <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.|"></span>
     <span th:if="${@rq.login && @rq.member.hasConnectedInstaMember()}" th:text="|${#lists.size(@rq.member.instaMember.toLikealbePeople)}/${#lists.size(@rq.member.instaMember.fromLikealbePeople)}|"></span>
+    -->
+    <div class="navbar max-w-2xl mx-auto bg-base-100">
+        <div class="navbar-start">
+            <div class="dropdown">
+                <label tabindex="0" class="btn btn-ghost btn-circle">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
+                    </svg>
+                </label>
+                <ul tabindex="0" class="menu menu-compact dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52">
+                    <li th:if="${@rq.logout}"><a href="/member/login"><i class="fa-solid fa-arrow-right-to-bracket"></i> 로그인</a></li>
+                    <li th:if="${@rq.logout}"><a href="/member/join"><i class="fa-solid fa-user-plus"></i> 회원가입</a></li>
+                    <li th:if="${@rq.login}"><a href="/member/me"><i class="fa-solid fa-user"></i> 내 정보</a></li>
+                    <li th:if="${@rq.login}">
+                        <a href="javascript:;" onclick="$(this).next().submit();">
+                            <i class="fa-solid fa-arrow-right-from-bracket"></i> 로그아웃
+                        </a>
+                        <form class="!hidden" th:action="|/member/logout|" method="POST"></form>
+                    </li>
+                    <li th:if="${@rq.login}"><a href="/instaMember/connect"><i class="fa-brands fa-instagram"></i> 인스타 ID 입력</a></li>
+                    <li th:if="${@rq.login}"><a href="/likeablePerson/add"><i class="fa-solid fa-heart-circle-plus"></i> 호감표시</a></li>
+                    <li th:if="${@rq.login}"><a href="/likeablePerson/list"><i class="fa-solid fa-list-ol"></i> 호감목록</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="navbar-center">
+            <a href="/" class="btn btn-ghost normal-case text-xl">gramgram</a>
+        </div>
+        <div class="navbar-end">
+            <button class="btn btn-ghost btn-circle">
+                <div class="indicator">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                    </svg>
+                    <span class="badge badge-xs badge-primary indicator-item"></span>
+                </div>
+            </button>
+        </div>
+    </div>
 </header>
 
-<main layout:fragment="main"></main>
+<main class="min-h-screen flex flex-col" layout:fragment="main"></main>
 
 <script th:inline="javascript">
     // 타임리프 문법(파라미터, ? 뒤에 입력된 매개변수들)

--- a/src/main/resources/templates/usr/member/join.html
+++ b/src/main/resources/templates/usr/member/join.html
@@ -45,17 +45,20 @@
         }
     </script>
 
-    <form th:action method="POST" class="p-10 flex flex-col gap-4" onsubmit="JoinForm__submit(this); return false;">
-        <div>
-            <input type="text" name="username" maxlength="30" placeholder="아이디" class="input input-bordered">
-        </div>
-        <div>
-            <input type="password" name="password" maxlength="30" placeholder="비밀번호" class="input input-bordered">
-        </div>
-        <div>
-            <input type="submit" value="회원가입" class="btn btn-primary">
-        </div>
-    </form>
+    <div>
+        <form th:action method="POST" class="p-10 flex flex-col gap-4" onsubmit="JoinForm__submit(this); return false;">
+            <div>
+                <input type="text" name="username" maxlength="30" placeholder="아이디" class="input input-bordered">
+            </div>
+            <div>
+                <input type="password" name="password" maxlength="30" placeholder="비밀번호" class="input input-bordered">
+            </div>
+            <div>
+                <input type="submit" value="회원가입" class="btn btn-primary">
+            </div>
+        </form>
+    </div>
+
 </main>
 
 </body>

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -67,7 +67,7 @@
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/naver">
-            네이버 로그인하기(아직 안됨)
+            네이버 로그인하기
         </a>
     </div>
 </main>

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -6,11 +6,14 @@
 
 <body>
 
+<!-- 테일윈드 불러오기 -->
+<script src="https://cdn.tailwindcss.com"></script>
+
 <main layout:fragment="main">
+
     <script>
         function LoginForm__submit(form) {
             // username 이(가) 올바른지 체크
-
             form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
             if (form.username.value.length == 0) {
@@ -44,7 +47,62 @@
             form.submit(); // 폼 발송
         }
     </script>
+    <div class="flex-grow flex items-center justify-center">
+        <div class="max-w-2xl w-full px-4">
+            <h1 class="mb-4">
+                <i class="fa-solid fa-arrow-right-to-bracket"></i>
+                로그인
+            </h1>
 
+            <form th:action method="POST" class="flex flex-col gap-6" onsubmit="LoginForm__submit(this); return false;">
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text">아이디</span>
+                    </label>
+                    <input type="text" name="username" maxlength="30" placeholder="아이디" class="input input-bordered" autofocus />
+                </div>
+
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text">비빌번호</span>
+                    </label>
+                    <input type="password" name="password" maxlength="30" placeholder="비빌번호" class="input input-bordered" />
+                </div>
+
+                <button class="btn btn-block btn-primary gap-1">
+                    <i class="fa-solid fa-arrow-right-to-bracket"></i>
+                    <span>로그인</span>
+                </button>
+
+            </form>
+
+            <div class="flex flex-col gap-6">
+                <a href="/oauth2/authorization/kakao" class="btn btn-block btn-outline gap-1">
+                    <i class="fa-solid fa-comment text-[color:#ffe812]"></i>
+                    <span>카카오 로그인</span>
+                </a>
+
+                <a href="/oauth2/authorization/naver" class="btn btn-block btn-outline gap-1">
+                    <i class="fa-solid fa-n text-[color:#2DB400]"></i>
+                    <span>네이버 로그인</span>
+                </a>
+
+                <a href="/oauth2/authorization/google" class="btn btn-block btn-outline gap-1">
+                    <i class="fa-brands fa-google text-[color:#ff4000]"></i>
+                    <span>구글 로그인</span>
+                </a>
+            </div>
+
+            <div class="flex flex-wrap justify-center">
+                <a href="/member/join" class="btn btn-link">회원가입</a>
+                <a href="#" class="btn btn-link">아이디찾기</a>
+                <a href="#" class="btn btn-link">비밀번호찾기</a>
+            </div>
+        </div>
+    </div>
+
+
+    <!--
     <form th:action method="POST" class="p-10 flex flex-col gap-4" onsubmit="LoginForm__submit(this); return false;">
         <div>
             <input type="text" name="username" maxlength="30" placeholder="아이디" class="input input-bordered">
@@ -56,21 +114,9 @@
             <input type="submit" value="로그인" class="btn btn-primary">
         </div>
     </form>
-
-    <div>
-        <a class="btn btn-link" href="/oauth2/authorization/kakao">
-            카카오로 로그인하기
-        </a>
-
-        <a class="btn btn-link" href="/oauth2/authorization/google">
-            구글 로그인하기
-        </a>
-
-        <a class="btn btn-link" href="/oauth2/authorization/naver">
-            네이버 로그인하기
-        </a>
-    </div>
+    -->
 </main>
+
 </body>
 
 </html>


### PR DESCRIPTION
## [2Week] 허준홍

### 미션 요구사항 분석 & 체크리스트

---

- [x] 케이스 4 : 한명의 인스타회원이 다른 인스타회원에게 중복으로 호감표시를 할 수 없습니다.
  - [x] 같은 대상에게 호감을 표시하면 중복으로 이기 때문에 처리를 하지 않는다. (rq.historyBack)


- [x] 케이스 5 : 한명의 인스타회원이 11명 이상의 호감상대를 등록 할 수 없습니다.
  - [x] 10명까지 호감표시를 하고 11명 째 호감표시에서 처리되면 안된다. (rq.historyBack)

  
- [x] 케이스 6 : 케이스 4 가 발생했을 때 기존의 사유와 다른 사유로 호감을 표시하는 경우에는 성공으로 처리
  - [x] 같은 대상에게 호감을 표시할 때 사유가 다르다면 수정으로 처리하고 사유만 수정한다.
  - [x] resultCode = S-2
  - [x] msg=bbbb 에 대한 호감사유를 외모에서 성격으로 변경합니다.


- [x] 네이버 로그인
    - [x] 스프링 OAuth2 클라이언트로 구현
    - [x] 네이버 로그인으로 가입한 회원의 providerTypeCode : NAVER




### 2주차 미션 요약

---
**[접근 방법]**

체크리스트를 중심으로 각각의 기능을 구현하기 위해 어떤 생각을 했는지 정리합니다. .

- 같은 대상에게 호감을 표시하면 중복으로 이기 때문에 처리를 하지 않는다. (rq.historyBack)
  - 먼저 같은대상을 찾는게 중요하다고 생각했다. LikeablePerson에서 fromInstamember가 현재 로그인한 member의 instamember와 동일한 접속자이다.
  - 이 상태에서 addForm에서 전달받은 username이 호감을 표시하고 등록하려는 대상이다. 그렇다면 LikeablePerson에서 toInstamember의 username 전달받은 username과
똑같으면 이미 호감을 표시하여 LikeablePerson에 저장되어 있는 대상이기 때문에 중복으로 처리한다. exist라는 메서드를 만들어 existLikeablePeople에 저장했다.
  - 처음에는 로그인한 member의 instamember의 getFromLikealbePeople()을 이용해서 List를 다 불러 온 후 반복문으로 찾아냈지만, 이 후에
    JPA 함수에서 언더바(_)를 사용하여 관련 엔티티의 필드까지 검색조건으로 활용하여 필요한 LikeablePerson을 한 번에 불러오도록 했다.
  - historyBack은 rsData.of를 F-x (Fail)로 return하여 historyBack이 되도록 했다.


- 10명까지 호감표시를 하고 11명 째 호감표시에서 처리되면 안된다. (rq.historyBack)
  - 로그인한 member의 instamember의 getFromLikealbePeople()을 이용해서 List를 다 불러와 list의 size()를 10명 이상이 되면 rsData.of로 Fail을 return하도록 했다.
  - rsData.of를 F-x (Fail)로 return하여 historyBack이 되도록 했다.


- 같은 대상에게 호감을 표시할 때 사유가 다르다면 수정으로 처리하고 사유만 수정한다.
  - 이미 존재하는 대상의 LikealbePerson의 정보가 담긴 객체 existLikeablePeople의 호감 사유인 getAttractiveTypeCode()가 
새로 입력받아 들어온 attractiveTypeCode와 다르면 수정으로 처리하도록 했다.
  - modify(existLikeablePeople,attractiveTypeCode) 메서드를 이용해서 기존의 호감사유를 String beforeAttractive 에 저장해두고
호감 사유를 attractiveTypeCode로 수정하였다.
  - 수정 성공의 msg에는 "%s에 대한 호감사유를 %s에서 %s으로 변경합니다.".formatted(modifyLikeablePeople.getToInstaMember().getUsername()
    ,beforeAttractive,modifyLikeablePeople.getAttractiveTypeDisplayName()),modifyLikeablePeople 을 이용했다.
  - 현재 수정하는 [호감대상의 이름]에 대한 [이전의 호감사유]에서 [새로 받아온 attractiveTypeCode(호감사유)]으로 변경합니다.


- 스프링 OAuth2 클라이언트로 구현
  - 네이버 API에서 API 생성후 OAuth 클라이언트 ID 와 비밀번호를 발급 받았다.
  - 발급 받은 클라이언트 ID와 비밀번호를 yml에 추가했고 provider도 등록해주었다.



- 네이버 로그인으로 가입한 회원의 providerTypeCode : NAVER
  - 카카오톡 로그인을 위해 구현되어 있던 CustomOAuth2UserService.java를 통해 NAVER 로그인을 가능케 했다.
  - whenSocialLogin을 통해 최초 로그인 시 join이 발생
  - 소셜 로그인으로 로그인할 때는 비밀번호가 없다.


**[특이사항]**

구현 과정에서 아쉬웠던 점 / 궁금했던 점을 정리합니다.

- 네이버 로그인시 provider에서 user-name-attribute: response 로 받아오다 보니 id뿐만 아니라 다른 정보들도 한 번에 oauthId에 저장이 되어서
정보를 따로 불러오기 위해 OAuth2UserInfo를 상속받은 NaverUserInfo를 만들었는데 아직 어떻게 동작하는지 완벽하게 이해가 되지 않는다.

